### PR TITLE
style: unify heading scale and weights

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -14,7 +14,7 @@ export default function BlogIndex() {
 
   return (
     <div className="mx-auto max-w-[65ch] px-6 py-24">
-      <h1 className="font-sans mb-12 text-[28px] font-bold">
+      <h1 className="font-sans mb-12 text-[36px] font-bold">
         Writing
       </h1>
       <ul className="flex flex-col gap-3">

--- a/app/globals.css
+++ b/app/globals.css
@@ -83,7 +83,7 @@ html[data-theme="dark"] .shiki span {
 .prose-site h1 {
   font-family: var(--font-sans);
   font-weight: 700;
-  font-size: 40px;
+  font-size: 36px;
   line-height: 1.15;
   letter-spacing: -0.01em;
   margin: 0 0 1.25rem;
@@ -91,14 +91,14 @@ html[data-theme="dark"] .shiki span {
 .prose-site h2 {
   font-family: var(--font-sans);
   font-weight: 700;
-  font-size: 28px;
+  font-size: 24px;
   line-height: 1.25;
   margin: 2.5rem 0 1rem;
 }
 .prose-site h3 {
   font-family: var(--font-sans);
-  font-weight: 500;
-  font-size: 22px;
+  font-weight: 700;
+  font-size: 20px;
   line-height: 1.3;
   margin: 2rem 0 0.75rem;
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function NotFound() {
   return (
     <div className="mx-auto flex min-h-screen max-w-[60ch] flex-col items-center justify-center gap-6 px-6 py-24 text-center">
-      <p className="font-serif">Nothing here.</p>
+      <p className="font-sans">Nothing here.</p>
       <Link href="/" className="font-sans text-sm">
         ← Home
       </Link>

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -31,7 +31,7 @@ export default function ResumePage() {
   return (
     <div className="mx-auto max-w-[70ch] px-6 py-24">
       <section>
-        <h2 className="font-sans mb-10 text-[28px] font-bold">
+        <h2 className="font-sans mb-10 text-[24px] font-bold">
           Work
         </h2>
         <div className="space-y-10">
@@ -42,7 +42,7 @@ export default function ResumePage() {
       </section>
 
       <section className="mt-20">
-        <h2 className="font-sans mb-10 text-[28px] font-bold">
+        <h2 className="font-sans mb-10 text-[24px] font-bold">
           Education
         </h2>
         <div className="space-y-10">
@@ -53,7 +53,7 @@ export default function ResumePage() {
       </section>
 
       <section className="mt-20">
-        <h2 className="font-sans mb-10 text-[28px] font-bold">
+        <h2 className="font-sans mb-10 text-[24px] font-bold">
           Publications
         </h2>
         <div className="space-y-10">

--- a/components/blog/PostFooter.tsx
+++ b/components/blog/PostFooter.tsx
@@ -29,7 +29,7 @@ export function PostFooter({
 
       {places.length > 0 ? (
         <div className="mb-8">
-          <h3 className="font-sans mb-2 text-[18px] font-medium">
+          <h3 className="font-sans mb-2 text-[20px] font-bold">
             Places mentioned
           </h3>
           <ul className="font-serif flex flex-col gap-1">

--- a/components/blog/PostHeader.tsx
+++ b/components/blog/PostHeader.tsx
@@ -13,7 +13,7 @@ export function PostHeader({ post }: { post: BlogPost }) {
         </div>
       ) : null}
       <h1
-        className="font-sans mt-3 text-[40px] font-bold leading-[1.15]"
+        className="font-sans mt-3 text-[36px] font-bold leading-[1.15]"
         style={{ color: "var(--fg)" }}
       >
         {post.title}

--- a/components/blog/PostListRow.tsx
+++ b/components/blog/PostListRow.tsx
@@ -23,7 +23,7 @@ export function PostListRow({ post }: { post: BlogPost }) {
             </span>
           ) : null}
         </span>
-        <span className="font-serif text-[20px] transition-colors motion-safe:duration-[var(--duration-fast)] group-hover:text-[var(--accent)]">
+        <span className="font-sans text-[20px] transition-colors motion-safe:duration-[var(--duration-fast)] group-hover:text-[var(--accent)]">
           {post.title}
         </span>
       </Link>

--- a/components/map/PinPopover.tsx
+++ b/components/map/PinPopover.tsx
@@ -38,7 +38,7 @@ export function PinPopover({ pin, x, y, onClose }: Props) {
       }}
     >
       <div className="flex items-center gap-3">
-        <h3 id={headingId} className="font-sans text-[20px] font-medium">
+        <h3 id={headingId} className="font-sans text-[20px] font-bold">
           {pin.name}
         </h3>
         <span
@@ -76,7 +76,7 @@ export function PinPopover({ pin, x, y, onClose }: Props) {
       ) : null}
       {pin.blog_slugs.length > 0 ? (
         <div className="mt-4">
-          <h4 className="font-sans text-[16px] font-medium">
+          <h4 className="font-sans text-[16px] font-bold">
             Related writing
           </h4>
           <ul className="font-serif mt-1 flex flex-col gap-1 text-sm">

--- a/components/resume/EducationEntry.tsx
+++ b/components/resume/EducationEntry.tsx
@@ -11,7 +11,7 @@ export function EducationEntry({ entry }: { entry: Edu }) {
 
   return (
     <article className="grid grid-cols-[1fr_auto] items-baseline gap-x-6 gap-y-2">
-      <h3 className="font-sans text-[22px] font-medium leading-tight">
+      <h3 className="font-sans text-[20px] font-bold leading-tight">
         {entry.degree}
       </h3>
       <div

--- a/components/resume/WorkEntry.tsx
+++ b/components/resume/WorkEntry.tsx
@@ -20,7 +20,7 @@ export function WorkEntry({
 
   return (
     <article className="space-y-3">
-      <h3 className="font-sans text-[22px] font-medium leading-tight">
+      <h3 className="font-sans text-[20px] font-bold leading-tight">
         {entry.role}
       </h3>
       <div className="font-serif text-sm" style={{ color: "var(--fg-muted)" }}>


### PR DESCRIPTION
## Summary

- Collapse heading sizes to a single scale across JSX and MDX prose: h1=36, h2=24, h3=20, h4=16.
- Use a single font-weight (700) for all headings; hierarchy is carried by size alone.
- Fix two font-family inconsistencies where UI text used the serif body font: `app/not-found.tsx` "Nothing here." and `components/blog/PostListRow.tsx` post titles.

Why: design aesthetic calls for fewer variations and consistent use of Lato for headings / Alegreya for body. Prior state had three sizes for h3 (22/20/18), mismatched h1 sizes (40 article vs 28 index), and `font-medium` on h3/h4 that had no matching loaded Lato weight (Lato ships 100/300/400/700/900; no 500).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 68 tests passing
- [x] `npm run build` succeeds (with `NEXT_PUBLIC_SITE_URL` set)
- [ ] Visual check on `/`, `/blog`, `/blog/on-jazz`, `/resume`, `/map`, `/404` in light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)