### PR TITLE
feat(map): split into US and world views with zoom toggle

### DIFF
--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -3,14 +3,21 @@ import { feature } from "topojson-client";
 import type { Topology, GeometryCollection } from "topojson-specification";
 import type { ExtendedFeatureCollection } from "d3-geo";
 import worldTopo from "world-atlas/countries-110m.json";
+import statesTopo from "us-atlas/states-10m.json";
 import { getPins } from "@/lib/content";
 import {
   countryPathsFromGeojson,
+  statePathsFromGeojson,
   projectPoint,
+  projectUsPoint,
+  isUsPin,
   MAP_WIDTH,
   MAP_HEIGHT,
+  US_MAP_WIDTH,
+  US_MAP_HEIGHT,
 } from "@/lib/projection";
-import { MapCanvas, type ProjectedPin } from "@/components/map/MapCanvas";
+import { type ProjectedPin } from "@/components/map/MapCanvas";
+import { MapSwitcher } from "@/components/map/MapSwitcher";
 
 export const metadata: Metadata = {
   title: "Map",
@@ -18,27 +25,51 @@ export const metadata: Metadata = {
 };
 
 export default function MapPage() {
-  const topo = worldTopo as unknown as Topology<{
-    countries: GeometryCollection;
-  }>;
-  const countries = feature(
-    topo,
-    topo.objects.countries,
-  ) as unknown as ExtendedFeatureCollection;
-  const countryPaths = countryPathsFromGeojson(countries);
+  const pins = getPins();
 
-  const pins: ProjectedPin[] = getPins().map((pin) => {
-    const [x, y] = projectPoint(pin.lon, pin.lat);
-    return { pin, x, y };
-  });
+  const worldGeo = feature(
+    worldTopo as unknown as Topology<{ countries: GeometryCollection }>,
+    (worldTopo as unknown as Topology<{ countries: GeometryCollection }>)
+      .objects.countries,
+  ) as unknown as ExtendedFeatureCollection;
+  const countryPaths = countryPathsFromGeojson(worldGeo);
+
+  const statesGeo = feature(
+    statesTopo as unknown as Topology<{ states: GeometryCollection }>,
+    (statesTopo as unknown as Topology<{ states: GeometryCollection }>).objects
+      .states,
+  ) as unknown as ExtendedFeatureCollection;
+  const statePaths = statePathsFromGeojson(statesGeo);
+
+  const usPins: ProjectedPin[] = [];
+  const worldPins: ProjectedPin[] = [];
+  for (const pin of pins) {
+    const [wx, wy] = projectPoint(pin.lon, pin.lat);
+    worldPins.push({ pin, x: wx, y: wy });
+    if (isUsPin(pin)) {
+      const xy = projectUsPoint(pin.lon, pin.lat);
+      if (xy) usPins.push({ pin, x: xy[0], y: xy[1] });
+    }
+  }
 
   return (
-    <MapCanvas
-      viewBox={`0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`}
-      width={MAP_WIDTH}
-      height={MAP_HEIGHT}
-      countryPaths={countryPaths}
-      pins={pins}
+    <MapSwitcher
+      usMap={{
+        ariaLabel: "United States map",
+        viewBox: `0 0 ${US_MAP_WIDTH} ${US_MAP_HEIGHT}`,
+        width: US_MAP_WIDTH,
+        height: US_MAP_HEIGHT,
+        regionPaths: statePaths,
+        pins: usPins,
+      }}
+      worldMap={{
+        ariaLabel: "World map",
+        viewBox: `0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`,
+        width: MAP_WIDTH,
+        height: MAP_HEIGHT,
+        regionPaths: countryPaths,
+        pins: worldPins,
+      }}
     />
   );
 }

--- a/components/map/MapCanvas.tsx
+++ b/components/map/MapCanvas.tsx
@@ -14,32 +14,33 @@ interface Props {
   viewBox: string;
   width: number;
   height: number;
-  countryPaths: string[];
+  regionPaths: string[];
   pins: ProjectedPin[];
+  ariaLabel: string;
 }
 
 export function MapCanvas({
   viewBox,
   width,
   height,
-  countryPaths,
+  regionPaths,
   pins,
+  ariaLabel,
 }: Props) {
   const [openId, setOpenId] = useState<string | null>(null);
   const [shiftX, setShiftX] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Hash linking: open the matching pin on mount.
+  // Hash linking: open the matching pin on mount. If this canvas has no
+  // matching pin we stay silent — a sibling canvas on the same page may
+  // own the id, so we must not clear or steal the hash.
   useEffect(() => {
     if (typeof window === "undefined") return;
     const tryOpen = () => {
       const hash = window.location.hash.slice(1);
       if (!hash) return;
       const match = pins.find((p) => p.pin.id === hash);
-      if (!match) {
-        history.replaceState(null, "", window.location.pathname);
-        return;
-      }
+      if (!match) return;
       setOpenId(match.pin.id);
       const el = containerRef.current;
       if (el) {
@@ -77,11 +78,11 @@ export function MapCanvas({
         viewBox={viewBox}
         className="absolute inset-0 h-full w-full transition-transform motion-safe:duration-[var(--duration-medium)]"
         style={{ transform: `translateX(${shiftX}px)` }}
-        aria-label="World map"
+        aria-label={ariaLabel}
         role="img"
       >
         <g>
-          {countryPaths.map((d, i) => (
+          {regionPaths.map((d, i) => (
             <path
               key={i}
               d={d}

--- a/components/map/MapInsetButton.tsx
+++ b/components/map/MapInsetButton.tsx
@@ -19,7 +19,7 @@ export const MapInsetButton = forwardRef<HTMLButtonElement, Props>(function MapI
       type="button"
       onClick={onClick}
       aria-label={ariaLabel}
-      className="fixed bottom-8 right-8 z-20 h-[84px] w-36 overflow-hidden rounded-sm border border-[var(--border)] bg-[var(--bg)] shadow-sm transition-[border-color,transform] motion-safe:duration-[var(--duration-fast)] hover:border-[var(--accent)] hover:scale-[1.03] focus-visible:border-[var(--accent)] focus-visible:outline-none"
+      className="fixed bottom-8 right-8 z-20 h-[84px] w-36 overflow-hidden rounded-sm border border-[var(--border)] bg-[var(--bg)] shadow-sm transition-colors motion-safe:duration-[var(--duration-fast)] hover:border-[var(--accent)] focus-visible:border-[var(--accent)] focus-visible:outline-none"
     >
       <svg
         viewBox={viewBox}

--- a/components/map/MapInsetButton.tsx
+++ b/components/map/MapInsetButton.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { forwardRef } from "react";
+
+interface Props {
+  viewBox: string;
+  regionPaths: string[];
+  ariaLabel: string;
+  onClick: () => void;
+}
+
+export const MapInsetButton = forwardRef<HTMLButtonElement, Props>(function MapInsetButton(
+  { viewBox, regionPaths, ariaLabel, onClick },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className="fixed bottom-8 right-8 z-20 h-[84px] w-36 overflow-hidden rounded-sm border border-[var(--border)] bg-[var(--bg)] shadow-sm transition-[border-color,transform] motion-safe:duration-[var(--duration-fast)] hover:border-[var(--accent)] hover:scale-[1.03] focus-visible:border-[var(--accent)] focus-visible:outline-none"
+    >
+      <svg
+        viewBox={viewBox}
+        className="h-full w-full"
+        preserveAspectRatio="xMidYMid slice"
+        aria-hidden="true"
+      >
+        {regionPaths.map((d, i) => (
+          <path
+            key={i}
+            d={d}
+            fill="var(--border)"
+            stroke="var(--fg-muted)"
+            strokeWidth={0.5}
+            vectorEffect="non-scaling-stroke"
+          />
+        ))}
+      </svg>
+    </button>
+  );
+});

--- a/components/map/MapSwitcher.tsx
+++ b/components/map/MapSwitcher.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { MapCanvas, type ProjectedPin } from "./MapCanvas";
+import { MapInsetButton } from "./MapInsetButton";
+
+interface MapData {
+  viewBox: string;
+  width: number;
+  height: number;
+  regionPaths: string[];
+  pins: ProjectedPin[];
+  ariaLabel: string;
+}
+
+interface Props {
+  usMap: MapData;
+  worldMap: MapData;
+}
+
+type ActiveMap = "us" | "world";
+
+const ZOOM_DURATION_MS = 750;
+const ZOOM_EASING = "cubic-bezier(0.2, 0, 0, 1)";
+
+export function MapSwitcher({ usMap, worldMap }: Props) {
+  const [active, setActive] = useState<ActiveMap>("us");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const usLayerRef = useRef<HTMLDivElement>(null);
+  const worldLayerRef = useRef<HTMLDivElement>(null);
+  const insetRef = useRef<HTMLButtonElement>(null);
+  const didMountRef = useRef(false);
+
+  // Route deep links to whichever map owns the pin.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const route = () => {
+      const hash = window.location.hash.slice(1);
+      if (!hash) return;
+      const inUs = usMap.pins.some((p) => p.pin.id === hash);
+      const inWorld = worldMap.pins.some((p) => p.pin.id === hash);
+      if (!inUs && inWorld) setActive("world");
+      else if (!inWorld && inUs) setActive("us");
+    };
+    route();
+    window.addEventListener("hashchange", route);
+    return () => window.removeEventListener("hashchange", route);
+  }, [usMap.pins, worldMap.pins]);
+
+  // FLIP-style zoom: the newly-active layer starts at the inset's rect and
+  // animates to fill the container. Runs synchronously before paint so the
+  // full-size version never flashes.
+  useLayoutEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    const inset = insetRef.current;
+    const container = containerRef.current;
+    const incoming =
+      active === "us" ? usLayerRef.current : worldLayerRef.current;
+    const outgoing =
+      active === "us" ? worldLayerRef.current : usLayerRef.current;
+    if (!inset || !container || !incoming) return;
+
+    const prefersReduced =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (prefersReduced) return;
+
+    const insetRect = inset.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    const sx = insetRect.width / containerRect.width;
+    const sy = insetRect.height / containerRect.height;
+    const tx = insetRect.left - containerRect.left;
+    const ty = insetRect.top - containerRect.top;
+
+    incoming.animate(
+      [
+        {
+          transform: `translate(${tx}px, ${ty}px) scale(${sx}, ${sy})`,
+          transformOrigin: "0 0",
+          opacity: 0,
+        },
+        {
+          transform: "translate(0px, 0px) scale(1, 1)",
+          transformOrigin: "0 0",
+          opacity: 1,
+        },
+      ],
+      { duration: ZOOM_DURATION_MS, easing: ZOOM_EASING, fill: "backwards" },
+    );
+
+    outgoing?.animate(
+      [{ opacity: 1 }, { opacity: 0 }],
+      { duration: ZOOM_DURATION_MS, easing: ZOOM_EASING },
+    );
+  }, [active]);
+
+  const insetMap = active === "us" ? worldMap : usMap;
+  const insetLabel =
+    active === "us" ? "Switch to world map" : "Switch to United States map";
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative h-[calc(100vh-56px)] md:h-screen overflow-hidden"
+    >
+      <Layer ref={usLayerRef} visible={active === "us"}>
+        <MapCanvas {...usMap} />
+      </Layer>
+      <Layer ref={worldLayerRef} visible={active === "world"}>
+        <MapCanvas {...worldMap} />
+      </Layer>
+      <MapInsetButton
+        ref={insetRef}
+        viewBox={insetMap.viewBox}
+        regionPaths={insetMap.regionPaths}
+        ariaLabel={insetLabel}
+        onClick={() => setActive(active === "us" ? "world" : "us")}
+      />
+    </div>
+  );
+}
+
+const Layer = function Layer({
+  visible,
+  children,
+  ref,
+}: {
+  visible: boolean;
+  children: React.ReactNode;
+  ref: React.RefObject<HTMLDivElement | null>;
+}) {
+  return (
+    <div
+      ref={ref}
+      aria-hidden={!visible}
+      className={
+        "absolute inset-0 " +
+        (visible ? "opacity-100" : "pointer-events-none opacity-0")
+      }
+    >
+      {children}
+    </div>
+  );
+};

--- a/components/map/MapSwitcher.tsx
+++ b/components/map/MapSwitcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { MapCanvas, type ProjectedPin } from "./MapCanvas";
 import { MapInsetButton } from "./MapInsetButton";
 
@@ -29,10 +29,14 @@ export function MapSwitcher({ usMap, worldMap }: Props) {
   const usLayerRef = useRef<HTMLDivElement>(null);
   const worldLayerRef = useRef<HTMLDivElement>(null);
   const insetRef = useRef<HTMLButtonElement>(null);
-  const didMountRef = useRef(false);
+  // Only animate when the user clicks the inset. Skips hash-routing and
+  // any other programmatic state changes that happen before interaction.
+  const userInitiatedRef = useRef(false);
 
-  // Route deep links to whichever map owns the pin.
-  useEffect(() => {
+  // Route deep links to whichever map owns the pin. Runs as a layout
+  // effect so the correct `active` is committed before the next paint —
+  // no visible swap for URLs like /map#vancouver.
+  useLayoutEffect(() => {
     if (typeof window === "undefined") return;
     const route = () => {
       const hash = window.location.hash.slice(1);
@@ -51,10 +55,7 @@ export function MapSwitcher({ usMap, worldMap }: Props) {
   // animates to fill the container. Runs synchronously before paint so the
   // full-size version never flashes.
   useLayoutEffect(() => {
-    if (!didMountRef.current) {
-      didMountRef.current = true;
-      return;
-    }
+    if (!userInitiatedRef.current) return;
     const inset = insetRef.current;
     const container = containerRef.current;
     const incoming =
@@ -67,6 +68,10 @@ export function MapSwitcher({ usMap, worldMap }: Props) {
       typeof window !== "undefined" &&
       window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     if (prefersReduced) return;
+
+    // Cancel any in-flight zoom so rapid toggles don't stack animations.
+    incoming.getAnimations().forEach((a) => a.cancel());
+    outgoing?.getAnimations().forEach((a) => a.cancel());
 
     const insetRect = inset.getBoundingClientRect();
     const containerRect = container.getBoundingClientRect();
@@ -93,13 +98,18 @@ export function MapSwitcher({ usMap, worldMap }: Props) {
 
     outgoing?.animate(
       [{ opacity: 1 }, { opacity: 0 }],
-      { duration: ZOOM_DURATION_MS, easing: ZOOM_EASING },
+      { duration: ZOOM_DURATION_MS, easing: ZOOM_EASING, fill: "backwards" },
     );
   }, [active]);
 
   const insetMap = active === "us" ? worldMap : usMap;
   const insetLabel =
     active === "us" ? "Switch to world map" : "Switch to United States map";
+
+  const toggle = () => {
+    userInitiatedRef.current = true;
+    setActive(active === "us" ? "world" : "us");
+  };
 
   return (
     <div
@@ -117,13 +127,13 @@ export function MapSwitcher({ usMap, worldMap }: Props) {
         viewBox={insetMap.viewBox}
         regionPaths={insetMap.regionPaths}
         ariaLabel={insetLabel}
-        onClick={() => setActive(active === "us" ? "world" : "us")}
+        onClick={toggle}
       />
     </div>
   );
 }
 
-const Layer = function Layer({
+function Layer({
   visible,
   children,
   ref,
@@ -135,13 +145,15 @@ const Layer = function Layer({
   return (
     <div
       ref={ref}
-      aria-hidden={!visible}
+      // `inert` removes the subtree from the a11y tree, tab order, and
+      // pointer input — necessary because the hidden map still contains
+      // focusable popover content (close buttons, external links).
+      inert={!visible}
       className={
-        "absolute inset-0 " +
-        (visible ? "opacity-100" : "pointer-events-none opacity-0")
+        "absolute inset-0 " + (visible ? "opacity-100" : "opacity-0")
       }
     >
       {children}
     </div>
   );
-};
+}

--- a/lib/__tests__/projection.test.ts
+++ b/lib/__tests__/projection.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from "vitest";
 import {
   projectPoint,
+  projectUsPoint,
+  isUsPin,
   MAP_WIDTH,
   MAP_HEIGHT,
+  US_MAP_WIDTH,
+  US_MAP_HEIGHT,
 } from "@/lib/projection";
 
 describe("projectPoint", () => {
@@ -28,5 +32,47 @@ describe("projectPoint", () => {
     const [xEast] = projectPoint(50, 0);
     const [xWest] = projectPoint(-50, 0);
     expect(xEast - MAP_WIDTH / 2).toBeCloseTo(MAP_WIDTH / 2 - xWest, 5);
+  });
+});
+
+describe("projectUsPoint", () => {
+  it("projects continental US points inside the US canvas", () => {
+    const xy = projectUsPoint(-74.006, 40.7128); // NYC
+    expect(xy).not.toBeNull();
+    const [x, y] = xy!;
+    expect(x).toBeGreaterThanOrEqual(0);
+    expect(x).toBeLessThanOrEqual(US_MAP_WIDTH);
+    expect(y).toBeGreaterThanOrEqual(0);
+    expect(y).toBeLessThanOrEqual(US_MAP_HEIGHT);
+  });
+
+  it("projects Alaska and Hawaii inside the US canvas via composite projection", () => {
+    const anchorage = projectUsPoint(-149.9003, 61.2181);
+    const honolulu = projectUsPoint(-157.8583, 21.3069);
+    expect(anchorage).not.toBeNull();
+    expect(honolulu).not.toBeNull();
+  });
+
+  it("returns null for points far outside any US region", () => {
+    // geoAlbersUsa clips by inset bounding boxes, not national borders,
+    // so nearby-foreign points (Vancouver, Tijuana) still project.
+    // Use isUsPin for true US classification.
+    expect(projectUsPoint(2.3522, 48.8566)).toBeNull(); // Paris
+    expect(projectUsPoint(151.2093, -33.8688)).toBeNull(); // Sydney
+  });
+});
+
+describe("isUsPin", () => {
+  it("returns true for US locations", () => {
+    expect(isUsPin({ lat: 40.7128, lon: -74.006 })).toBe(true); // NYC
+    expect(isUsPin({ lat: 35.994, lon: -78.8986 })).toBe(true); // Durham
+    expect(isUsPin({ lat: 61.2181, lon: -149.9003 })).toBe(true); // Anchorage
+    expect(isUsPin({ lat: 21.3069, lon: -157.8583 })).toBe(true); // Honolulu
+  });
+
+  it("returns false for international locations", () => {
+    expect(isUsPin({ lat: 49.2827, lon: -123.1207 })).toBe(false); // Vancouver
+    expect(isUsPin({ lat: 48.8566, lon: 2.3522 })).toBe(false); // Paris
+    expect(isUsPin({ lat: -33.8688, lon: 151.2093 })).toBe(false); // Sydney
   });
 });

--- a/lib/__tests__/projection.test.ts
+++ b/lib/__tests__/projection.test.ts
@@ -75,4 +75,12 @@ describe("isUsPin", () => {
     expect(isUsPin({ lat: 48.8566, lon: 2.3522 })).toBe(false); // Paris
     expect(isUsPin({ lat: -33.8688, lon: 151.2093 })).toBe(false); // Sydney
   });
+
+  it("returns false for US territories (documented limitation at 110m resolution)", () => {
+    // Territories aren't included in world-atlas 110m's US feature. A pin
+    // placed in any of these would currently render only on the world map.
+    expect(isUsPin({ lat: 18.4655, lon: -66.1057 })).toBe(false); // San Juan, PR
+    expect(isUsPin({ lat: 13.4443, lon: 144.7937 })).toBe(false); // Hagåtña, Guam
+    expect(isUsPin({ lat: 18.3358, lon: -64.8963 })).toBe(false); // St. Thomas, USVI
+  });
 });

--- a/lib/projection.ts
+++ b/lib/projection.ts
@@ -1,8 +1,14 @@
-import { geoEqualEarth, geoPath } from "d3-geo";
+import { geoEqualEarth, geoAlbersUsa, geoContains, geoPath } from "d3-geo";
 import type { ExtendedFeatureCollection } from "d3-geo";
+import { feature } from "topojson-client";
+import type { Topology, GeometryCollection } from "topojson-specification";
+import worldTopo from "world-atlas/countries-110m.json";
 
 export const MAP_WIDTH = 960;
 export const MAP_HEIGHT = 500;
+
+export const US_MAP_WIDTH = 960;
+export const US_MAP_HEIGHT = 600;
 
 /*
  * Shared Equal Earth projection, centered and scaled to fit
@@ -13,20 +19,66 @@ const projection = geoEqualEarth()
   .scale(175)
   .translate([MAP_WIDTH / 2, MAP_HEIGHT / 2]);
 
+/*
+ * Composite projection for the U.S. map — includes insets for Alaska,
+ * Hawaii, and Puerto Rico. Scaled and translated to fill the US canvas.
+ */
+const usProjection = geoAlbersUsa()
+  .scale(1200)
+  .translate([US_MAP_WIDTH / 2, US_MAP_HEIGHT / 2]);
+
+// US country geometry, used for point-in-polygon classification.
+// geoAlbersUsa's null check isn't reliable: it clips by bounding box,
+// not by actual borders, so Vancouver and Tijuana would slip through.
+const worldCountries = feature(
+  worldTopo as unknown as Topology<{ countries: GeometryCollection }>,
+  (worldTopo as unknown as Topology<{ countries: GeometryCollection }>).objects
+    .countries,
+) as unknown as ExtendedFeatureCollection;
+const usFeature = worldCountries.features.find(
+  (f) => f.properties?.name === "United States of America",
+);
+
 export function projectPoint(lon: number, lat: number): [number, number] {
   const xy = projection([lon, lat]);
   if (!xy) throw new Error(`Projection failed for (${lon}, ${lat})`);
   return [xy[0], xy[1]];
 }
 
-export function countryPathsFromGeojson(
+export function projectUsPoint(
+  lon: number,
+  lat: number,
+): [number, number] | null {
+  const xy = usProjection([lon, lat]);
+  return xy ? [xy[0], xy[1]] : null;
+}
+
+export function isUsPin(p: { lat: number; lon: number }): boolean {
+  if (!usFeature) return false;
+  return geoContains(usFeature, [p.lon, p.lat]);
+}
+
+export function regionPathsFromGeojson(
   fc: ExtendedFeatureCollection,
+  proj: typeof projection | typeof usProjection = projection,
 ): string[] {
-  const path = geoPath(projection);
+  const path = geoPath(proj);
   const out: string[] = [];
   for (const feature of fc.features) {
     const d = path(feature);
     if (d) out.push(d);
   }
   return out;
+}
+
+export function countryPathsFromGeojson(
+  fc: ExtendedFeatureCollection,
+): string[] {
+  return regionPathsFromGeojson(fc, projection);
+}
+
+export function statePathsFromGeojson(
+  fc: ExtendedFeatureCollection,
+): string[] {
+  return regionPathsFromGeojson(fc, usProjection);
 }

--- a/lib/projection.ts
+++ b/lib/projection.ts
@@ -53,6 +53,12 @@ export function projectUsPoint(
   return xy ? [xy[0], xy[1]] : null;
 }
 
+// Excludes US territories (Puerto Rico, Guam, USVI, Samoa, N. Mariana).
+// Neither world-atlas 110m nor the default geoAlbersUsa inset covers them,
+// so a territory pin would currently render only on the world map. If that
+// ever matters, switch to higher-resolution world-atlas and extend
+// geoAlbersUsa with explicit insets, or add an explicit region field to
+// MapPin.
 export function isUsPin(p: { lat: number; lon: number }): boolean {
   if (!usFeature) return false;
   return geoContains(usFeature, [p.lon, p.lat]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "remark-math": "^6.0.0",
         "shiki": "^4.0.2",
         "topojson-client": "^3.1.0",
+        "us-atlas": "^3.0.1",
         "world-atlas": "^2.0.2",
         "yaml": "^2.8.3",
         "zod": "^4.3.6"
@@ -9776,6 +9777,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/us-atlas": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/us-atlas/-/us-atlas-3.0.1.tgz",
+      "integrity": "sha512-wEIZCq0ImPvGblTd8gZMqNNCPkQshugMUG/8nkSWXb02+XqNFREg9atHOKP9w6prLZTpqcLhSvdBW81MkV3/0Q==",
+      "license": "ISC"
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "remark-math": "^6.0.0",
     "shiki": "^4.0.2",
     "topojson-client": "^3.1.0",
+    "us-atlas": "^3.0.1",
     "world-atlas": "^2.0.2",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"


### PR DESCRIPTION
Closes #4.

## Summary

- **Two map views** — a US states map and a world map. Only one is visible at a time; the other sits as a small rectangular inset in the bottom-right. Clicking the inset toggles which map is the hero.
- **FLIP-style zoom** — on toggle, the incoming map animates from the inset's position and size to fill the container (Web Animations API, 750ms, `cubic-bezier(0.2, 0, 0, 1)`). Outgoing map fades. Honors `prefers-reduced-motion`.
- **Pin classification** uses `geoContains` on the world-atlas US feature — `geoAlbersUsa` alone clips by bounding box, so it would classify Vancouver as US.
- **Pin scope** — US map shows only US pins; world map shows all pins. Hash deep-links route to whichever map owns the pin.

## Review fixes (second commit)

- Animation gate is now a `userInitiatedRef` set inside the inset's click handler. Previous `didMountRef` let hash-routed state changes (`/map#vancouver`) trigger the zoom on load.
- Hash routing moved to `useLayoutEffect` so the correct map is committed before the first paint.
- Hidden layer uses the `inert` attribute; `aria-hidden` + `pointer-events-none` doesn't remove focusable descendants (popover close button, links) from tab order.
- `element.animate()` calls now cancel prior animations and both use `fill: "backwards"` to defend against a 1-frame flash.
- Removed `hover:scale-[1.03]` from the inset button (design aesthetic forbids lingering animations on user-initiated actions; also stops sub-pixel drift in the measured FLIP start rect).
- US-territory behavior at 110m resolution is documented in `isUsPin` and locked in by tests (San Juan, Guam, USVI → `false`).

## Test plan

- [ ] Land on `/map` — US map shows by default; world map appears as an inset in the bottom-right
- [ ] Click the inset — world map zooms in from the inset rect; US becomes the inset
- [ ] Toggle back — US map zooms in from the inset rect; world becomes the inset
- [ ] With `prefers-reduced-motion: reduce`, the swap is instant (no animation)
- [ ] Deep-link `/map#vancouver` (world-only pin) while US is default — lands on world with the popover open, **no zoom animation** on arrival
- [ ] Deep-link `/map#nyc` — opens the nyc popover on the US map
- [ ] Keyboard: Tab through the page with US active — focus never enters the hidden world layer (no phantom popover controls)
- [ ] Rapid double-click on the inset doesn't stack animations
- [ ] Light and dark modes both read cleanly; inset border shifts to the muted accent on hover (no scale transform)
- [ ] Mobile: flagging for review — desktop was the design target

🤖 Generated with [Claude Code](https://claude.com/claude-code)
