### PR TITLE
nav icons + resume accordion, subtitle split, link styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -91,6 +91,15 @@ details[open]::details-content {
   block-size: auto;
 }
 
+/* Some browsers skip the first transition after [open] is applied unless
+   a starting-style is declared explicitly. */
+@starting-style {
+  details[open]::details-content {
+    opacity: 0;
+    block-size: 0;
+  }
+}
+
 /* KaTeX follows theme */
 .katex,
 .katex * {

--- a/app/globals.css
+++ b/app/globals.css
@@ -67,6 +67,30 @@ body {
   text-underline-offset: 2px;
 }
 
+/* Animate <details> open/close. `interpolate-size: allow-keywords` lets
+   block-size: auto participate in a transition; `::details-content`
+   targets everything inside <details> except <summary>. Browsers without
+   ::details-content support fall back to instant open/close. Reduced-
+   motion users get 0ms via the duration custom properties in theme.css. */
+html {
+  interpolate-size: allow-keywords;
+}
+
+details::details-content {
+  opacity: 0;
+  block-size: 0;
+  overflow: clip;
+  transition:
+    content-visibility var(--duration-medium) allow-discrete,
+    opacity var(--duration-medium) var(--ease-standard),
+    block-size var(--duration-medium) var(--ease-standard);
+}
+
+details[open]::details-content {
+  opacity: 1;
+  block-size: auto;
+}
+
 /* KaTeX follows theme */
 .katex,
 .katex * {

--- a/app/globals.css
+++ b/app/globals.css
@@ -49,14 +49,22 @@ body {
 @layer base {
   a {
     color: inherit;
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 2px;
+    text-decoration: none;
     transition: color var(--duration-fast) var(--ease-standard);
   }
   a:hover {
     color: var(--accent);
   }
+}
+
+/* Prose links keep underlines — inline link density in long-form reading
+   needs the always-visible affordance. UI-chrome links (nav, resume,
+   popovers, cards) drop the underline and rely on the color shift, matching
+   the side-nav label pattern. */
+.prose-site a {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
 }
 
 /* KaTeX follows theme */

--- a/components/nav/FloatingNav.tsx
+++ b/components/nav/FloatingNav.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { BookOpen, FileText, Home, Map } from "lucide-react";
 import type { ComponentType, SVGProps } from "react";
+import { NavIcon } from "./NavIcon";
 import { ThemeToggle } from "./ThemeToggle";
 
 interface NavItem {
@@ -41,7 +42,7 @@ export function FloatingNav() {
                 <Link
                   href={href}
                   aria-current={active ? "page" : undefined}
-                  className="group/item flex items-center gap-3 no-underline text-[color:var(--fg-muted)] hover:text-[color:var(--accent)] aria-[current=page]:text-[color:var(--accent)] transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)]"
+                  className="group/nav-item flex items-center gap-3 no-underline text-[color:var(--fg-muted)] hover:text-[color:var(--accent)] aria-[current=page]:text-[color:var(--accent)] transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)]"
                   onClick={(e) => {
                     // Pointer/touch activations: drop focus so :focus-within
                     // doesn't keep the nav expanded post-navigation. Keyboard
@@ -51,12 +52,7 @@ export function FloatingNav() {
                     if (e.detail > 0) e.currentTarget.blur();
                   }}
                 >
-                  <Icon
-                    width={20}
-                    height={20}
-                    strokeWidth={1.5}
-                    className="transition-[stroke-width] duration-[var(--duration-fast)] ease-[var(--ease-standard)] group-hover/item:stroke-2"
-                  />
+                  <NavIcon Icon={Icon} />
                   <span className="font-sans text-sm opacity-0 transition-opacity motion-safe:duration-[var(--duration-medium)] ease-[var(--ease-standard)] group-hover:opacity-100 group-focus-within:opacity-100">
                     {label}
                   </span>
@@ -91,9 +87,9 @@ export function FloatingNav() {
               href={href}
               aria-current={active ? "page" : undefined}
               aria-label={label}
-              className="flex h-full flex-1 items-center justify-center no-underline text-[color:var(--fg-muted)] aria-[current=page]:text-[color:var(--accent)]"
+              className="group/nav-item flex h-full flex-1 items-center justify-center no-underline text-[color:var(--fg-muted)] transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)] hover:text-[color:var(--accent)] aria-[current=page]:text-[color:var(--accent)]"
             >
-              <Icon width={22} height={22} strokeWidth={1.5} />
+              <NavIcon Icon={Icon} size={22} />
             </Link>
           );
         })}

--- a/components/nav/NavIcon.tsx
+++ b/components/nav/NavIcon.tsx
@@ -1,0 +1,20 @@
+import type { ComponentType, SVGProps } from "react";
+
+interface NavIconProps {
+  Icon: ComponentType<SVGProps<SVGSVGElement>>;
+  size?: number;
+  className?: string;
+}
+
+// Bold-on-hover icon for nav chrome. Requires the immediate hoverable
+// ancestor (Link or button) to carry `group/nav-item`.
+export function NavIcon({ Icon, size = 20, className = "" }: NavIconProps) {
+  return (
+    <Icon
+      width={size}
+      height={size}
+      strokeWidth={1.5}
+      className={`transition-[stroke-width] duration-[var(--duration-fast)] ease-[var(--ease-standard)] group-hover/nav-item:stroke-2 group-focus-visible/nav-item:stroke-2 ${className}`}
+    />
+  );
+}

--- a/components/nav/ThemeToggle.tsx
+++ b/components/nav/ThemeToggle.tsx
@@ -2,6 +2,7 @@
 
 import { Moon, Sun } from "lucide-react";
 import { useSyncExternalStore } from "react";
+import { NavIcon } from "./NavIcon";
 
 type Theme = "light" | "dark";
 
@@ -50,14 +51,9 @@ export function ThemeToggle() {
           /* ignore (private mode, etc.) */
         }
       }}
-      className="inline-flex h-6 w-6 items-center justify-center bg-transparent transition-colors motion-safe:duration-[var(--duration-medium)]"
-      style={{ color: "var(--fg-muted)" }}
+      className="group/nav-item inline-flex h-6 w-6 items-center justify-center bg-transparent text-[color:var(--fg-muted)] transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)] hover:text-[color:var(--accent)]"
     >
-      {theme === "light" ? (
-        <Sun width={20} height={20} strokeWidth={1.5} />
-      ) : (
-        <Moon width={20} height={20} strokeWidth={1.5} />
-      )}
+      <NavIcon Icon={theme === "light" ? Sun : Moon} />
     </button>
   );
 }

--- a/components/resume/WorkEntry.tsx
+++ b/components/resume/WorkEntry.tsx
@@ -14,9 +14,10 @@ export function WorkEntry({
   const relatedPosts = entry.blog_slugs
     .map((slug) => posts.find((p) => p.slug === slug))
     .filter((p): p is BlogPost => Boolean(p));
-  const relatedPins = entry.map_pin_ids
-    .map((id) => pins.find((p) => p.id === id))
-    .filter((p): p is MapPin => Boolean(p));
+  const locationPin =
+    entry.map_pin_ids
+      .map((id) => pins.find((p) => p.id === id))
+      .find((p): p is MapPin => Boolean(p)) ?? null;
 
   return (
     <article>
@@ -37,7 +38,11 @@ export function WorkEntry({
               <span>{entry.org}</span>
             )}
             {" · "}
-            {entry.location}
+            {locationPin ? (
+              <Link href={`/map#${locationPin.id}`}>{entry.location}</Link>
+            ) : (
+              entry.location
+            )}
             {" · "}
             {formatYearMonthRange(entry.start, entry.end)}
           </div>
@@ -48,25 +53,20 @@ export function WorkEntry({
               <li key={i}>{h}</li>
             ))}
           </ul>
-          {(relatedPosts.length > 0 || relatedPins.length > 0) && (
+          {relatedPosts.length > 0 && (
             <div className="text-sm" style={{ color: "var(--fg-muted)" }}>
               <span className="font-sans">Related: </span>
-              {[
-                ...relatedPosts.map((p) => (
+              {relatedPosts
+                .map((p) => (
                   <Link key={`p-${p.slug}`} href={`/blog/${p.slug}`}>
                     {p.title}
                   </Link>
-                )),
-                ...relatedPins.map((p) => (
-                  <Link key={`m-${p.id}`} href={`/map#${p.id}`}>
-                    {p.name}
-                  </Link>
-                )),
-              ].reduce<React.ReactNode[]>(
-                (acc, node, i) =>
-                  i === 0 ? [node] : [...acc, " · ", node],
-                [],
-              )}
+                ))
+                .reduce<React.ReactNode[]>(
+                  (acc, node, i) =>
+                    i === 0 ? [node] : [...acc, " · ", node],
+                  [],
+                )}
             </div>
           )}
         </div>

--- a/components/resume/WorkEntry.tsx
+++ b/components/resume/WorkEntry.tsx
@@ -19,49 +19,55 @@ export function WorkEntry({
     .filter((p): p is MapPin => Boolean(p));
 
   return (
-    <article className="space-y-3">
-      <h3 className="font-sans text-[20px] font-bold leading-tight">
-        {entry.role}
-      </h3>
-      <div className="font-serif text-sm" style={{ color: "var(--fg-muted)" }}>
-        {entry.org_url ? (
-          <a href={entry.org_url} target="_blank" rel="noopener noreferrer">
-            {entry.org}
-          </a>
-        ) : (
-          <span>{entry.org}</span>
-        )}
-        {" · "}
-        {entry.location}
-        {" · "}
-        {formatYearMonthRange(entry.start, entry.end)}
-      </div>
-      <ul className="list-disc space-y-1 pl-5">
-        {entry.highlights.map((h, i) => (
-          <li key={i}>{h}</li>
-        ))}
-      </ul>
-      {(relatedPosts.length > 0 || relatedPins.length > 0) && (
-        <div className="text-sm" style={{ color: "var(--fg-muted)" }}>
-          <span className="font-sans">Related: </span>
-          {[
-            ...relatedPosts.map((p) => (
-              <Link key={`p-${p.slug}`} href={`/blog/${p.slug}`}>
-                {p.title}
-              </Link>
-            )),
-            ...relatedPins.map((p) => (
-              <Link key={`m-${p.id}`} href={`/map#${p.id}`}>
-                {p.name}
-              </Link>
-            )),
-          ].reduce<React.ReactNode[]>(
-            (acc, node, i) =>
-              i === 0 ? [node] : [...acc, " · ", node],
-            [],
+    <article>
+      <details className="group/work">
+        <summary className="list-none cursor-pointer space-y-2 [&::-webkit-details-marker]:hidden">
+          <h3 className="font-sans text-[20px] font-bold leading-tight transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)] group-hover/work:text-[color:var(--accent)]">
+            {entry.role}
+          </h3>
+          <div className="font-serif text-sm" style={{ color: "var(--fg-muted)" }}>
+            {entry.org_url ? (
+              <a href={entry.org_url} target="_blank" rel="noopener noreferrer">
+                {entry.org}
+              </a>
+            ) : (
+              <span>{entry.org}</span>
+            )}
+            {" · "}
+            {entry.location}
+            {" · "}
+            {formatYearMonthRange(entry.start, entry.end)}
+          </div>
+        </summary>
+        <div className="mt-3 space-y-3">
+          <ul className="list-disc space-y-1 pl-5">
+            {entry.highlights.map((h, i) => (
+              <li key={i}>{h}</li>
+            ))}
+          </ul>
+          {(relatedPosts.length > 0 || relatedPins.length > 0) && (
+            <div className="text-sm" style={{ color: "var(--fg-muted)" }}>
+              <span className="font-sans">Related: </span>
+              {[
+                ...relatedPosts.map((p) => (
+                  <Link key={`p-${p.slug}`} href={`/blog/${p.slug}`}>
+                    {p.title}
+                  </Link>
+                )),
+                ...relatedPins.map((p) => (
+                  <Link key={`m-${p.id}`} href={`/map#${p.id}`}>
+                    {p.name}
+                  </Link>
+                )),
+              ].reduce<React.ReactNode[]>(
+                (acc, node, i) =>
+                  i === 0 ? [node] : [...acc, " · ", node],
+                [],
+              )}
+            </div>
           )}
         </div>
-      )}
+      </details>
     </article>
   );
 }

--- a/components/resume/WorkEntry.tsx
+++ b/components/resume/WorkEntry.tsx
@@ -21,10 +21,13 @@ export function WorkEntry({
   return (
     <article>
       <details className="group/work">
-        <summary className="list-none cursor-pointer space-y-2 [&::-webkit-details-marker]:hidden">
+        <summary className="list-none cursor-pointer space-y-1 [&::-webkit-details-marker]:hidden">
           <h3 className="font-sans text-[20px] font-bold leading-tight transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)] group-hover/work:text-[color:var(--accent)]">
             {entry.role}
           </h3>
+          {entry.subtitle ? (
+            <div className="font-serif italic">{entry.subtitle}</div>
+          ) : null}
           <div className="font-serif text-sm" style={{ color: "var(--fg-muted)" }}>
             {entry.org_url ? (
               <a href={entry.org_url} target="_blank" rel="noopener noreferrer">

--- a/content/resume/work.yaml
+++ b/content/resume/work.yaml
@@ -15,7 +15,8 @@
 
 - id: argonne-cobra
   org: Argonne National Laboratory
-  role: Junior Research Aide — Thermal and Structural Materials Modeling and Simulations
+  role: Junior Research Aide
+  subtitle: Thermal and Structural Materials Modeling and Simulations
   location: Lemont, IL
   start: "2025-05"
   end: "2025-08"
@@ -30,7 +31,8 @@
 
 - id: duke-uqcm-lab
   org: Duke University — Uncertainty Quantification in Computational Mechanics Lab
-  role: Undergraduate Researcher (advisor Prof. Johann Guilleminot)
+  role: Undergraduate Researcher
+  subtitle: Advised by Prof. Johann Guilleminot
   location: Durham, NC
   start: "2022-09"
   end: "2025-12"
@@ -43,7 +45,8 @@
 
 - id: sandia-cint-2024
   org: Sandia National Laboratories — Center for Integrated Nanotechnologies
-  role: Summer Research Intern (advisors Dr. Rémi Dingreville and Dr. Saaketh Desai)
+  role: Summer Research Intern
+  subtitle: Advised by Dr. Rémi Dingreville and Dr. Saaketh Desai
   location: Albuquerque, NM
   start: "2024-05"
   end: "2024-08"
@@ -56,7 +59,8 @@
 
 - id: sandia-cint-2023
   org: Sandia National Laboratories — Center for Integrated Nanotechnologies
-  role: Summer Research Intern (advisors Dr. Rémi Dingreville and Dr. Chongze Hu)
+  role: Summer Research Intern
+  subtitle: Advised by Dr. Rémi Dingreville and Dr. Chongze Hu
   location: Albuquerque, NM
   start: "2023-05"
   end: "2023-06"
@@ -69,7 +73,8 @@
 
 - id: duke-housecs59-fall25
   org: Duke University
-  role: Student Co-Instructor — HOUSECS 59 (Introduction to Energy and Climate Investing)
+  role: Student Co-Instructor
+  subtitle: HOUSECS 59 — Introduction to Energy and Climate Investing
   location: Durham, NC
   start: "2025-08"
   end: "2025-12"
@@ -80,7 +85,8 @@
 
 - id: duke-me336-ta
   org: Duke University — Dept. of Mechanical Engineering and Materials Science
-  role: Undergraduate Teaching Assistant — ME 336 (Introduction to Fluid Mechanics)
+  role: Undergraduate Teaching Assistant
+  subtitle: ME 336 — Introduction to Fluid Mechanics
   location: Durham, NC
   start: "2025-08"
   end: "2025-12"
@@ -91,7 +97,8 @@
 
 - id: duke-housecs59-spr24
   org: Duke University — Program in Education
-  role: Student Instructor — HOUSECS 59 (The Durham Giving Project)
+  role: Student Instructor
+  subtitle: HOUSECS 59 — The Durham Giving Project
   location: Durham, NC
   start: "2024-01"
   end: "2024-05"
@@ -102,7 +109,8 @@
 
 - id: duke-cs201-ta
   org: Duke University — Dept. of Computer Science
-  role: Undergraduate Teaching Assistant — COMPSCI 201 (Introduction to Data Structures and Algorithms)
+  role: Undergraduate Teaching Assistant
+  subtitle: COMPSCI 201 — Introduction to Data Structures and Algorithms
   location: Durham, NC
   start: "2023-08"
   end: "2024-05"
@@ -113,7 +121,8 @@
 
 - id: duke-randolph-ra
   org: Duke University
-  role: Resident Assistant — Randolph Dormitory
+  role: Resident Assistant
+  subtitle: Randolph Dormitory
   location: Durham, NC
   start: "2024-08"
   end: "2025-05"

--- a/design-aesthetic.md
+++ b/design-aesthetic.md
@@ -58,10 +58,19 @@ Animation should serve a clear purpose — it is not decorative. The appropriate
 
 ## Links & Hover States
 
-- Default state: underlined, body/UI color
-- Hover state: underline retained, color shifts to muted accent, weight increases
+Two modes, depending on context:
+
+**Prose links** — inline links inside long-form reading (blog posts, the about page, MDX bodies wrapped in `.prose-site`):
+- Default state: underlined, body color
+- Hover state: underline retained, color shifts to muted accent
 - Transition: `100–150ms ease`
-- No color-only differentiation (underline always present for accessibility)
+- The always-visible underline keeps dense inline link runs legible and accessible.
+
+**UI-chrome links** — standalone or structural links outside prose (nav labels, resume metadata, blog list rows, map popovers, footers, cards):
+- Default state: no underline, inherits surrounding text color (often `--fg-muted` when the link sits in metadata-style text)
+- Hover state: color shifts to muted accent, no underline added
+- Transition: `100–150ms ease`
+- Matches the side-nav label pattern — a quiet color shift does the work, keeping the chrome uncluttered.
 
 ---
 

--- a/lib/content/schemas.ts
+++ b/lib/content/schemas.ts
@@ -53,6 +53,7 @@ export const workEntrySchema = yearMonthRange({
   id: kebabCase,
   org: z.string().min(1),
   role: z.string().min(1),
+  subtitle: z.string().min(1).optional(),
   location: z.string().min(1),
   start: yearMonth,
   end: yearMonthOrNull,


### PR DESCRIPTION
## Summary

- **Nav chrome** — introduces a shared `NavIcon` component that bolds on hover/focus via `stroke-width 1.5 → 2`, and reuses it in `FloatingNav` (desktop + mobile) and `ThemeToggle` so Sun/Moon, home/resume/blog/map all share one consistent hover affordance.
- **Link styling** — drops the default `<a>` underline in favor of the muted→accent color shift the side-nav labels use; underline is re-scoped to `.prose-site a` so long-form reading keeps the always-visible affordance. `design-aesthetic.md` updated to document the two modes.
- **Resume accordion** — each work entry collapses its bullets + Related row into a native `<details>`, with the role as the `<summary>`. No arrow toggle — cursor-pointer + role color shift is the affordance. Pure CSS, zero JS.
- **Resume content** — splits advisor / class / group detail out of the `role` field into a new optional `subtitle` (rendered as serif italic under the role). Affects 9 entries; schema + YAML + renderer updated together.
- **Location → map** — the location text in each work entry now links to its map pin (first match in `map_pin_ids`); Related row no longer duplicates the pin.
- **Details animation** — `::details-content` + `interpolate-size: allow-keywords` gives a ~220ms block-size + opacity transition on open/close. `@starting-style` ensures the open animation fires reliably. `prefers-reduced-motion` collapses to 0ms via existing `--duration-medium` plumbing in `theme.css`.

## Test plan

- [ ] Hover each side-nav icon — icon bolds, color shifts to accent
- [ ] Hover the Sun/Moon toggle — matches nav-icon hover behavior
- [ ] Confirm prose links in `/` (about) and any blog post keep their underline; blog list rows, resume meta, map popover links have no underline but color-shift on hover
- [ ] On `/resume`, click a role — bullets slide open with a fade; click again — slides closed
- [ ] Verify advisor/class entries show role + italic subtitle + org/location/dates as three stacked lines
- [ ] Click the location text — navigates to the matching map pin
- [ ] Confirm Related row no longer shows locations, only blog posts, and is hidden when an entry has no related posts
- [ ] Enable `prefers-reduced-motion` in DevTools → accordion toggle is instant, not animated

🤖 Generated with [Claude Code](https://claude.com/claude-code)