### PR TITLE
perf(map): ship raw topology to client, shrink /map payload by ~63%

### DIFF
--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { feature } from "topojson-client";
-import type { Topology, GeometryCollection } from "topojson-specification";
 import type { ExtendedFeatureCollection } from "d3-geo";
 import worldTopo from "world-atlas/countries-110m.json";
 import statesTopo from "us-atlas/states-10m.json";
@@ -11,7 +10,11 @@ import {
   GLOBE_WIDTH,
   GLOBE_HEIGHT,
 } from "@/lib/projection";
-import { MapGlobe } from "@/components/map/MapGlobe";
+import {
+  MapGlobe,
+  type StatesTopology,
+  type WorldTopology,
+} from "@/components/map/MapGlobe";
 
 export const metadata: Metadata = {
   title: "Map",
@@ -26,17 +29,8 @@ const INITIAL_SCALE = 1;
 export default function MapPage() {
   const pins = getPins();
 
-  const worldFeatures = feature(
-    worldTopo as unknown as Topology<{ countries: GeometryCollection }>,
-    (worldTopo as unknown as Topology<{ countries: GeometryCollection }>)
-      .objects.countries,
-  ) as unknown as ExtendedFeatureCollection;
-
-  const stateFeatures = feature(
-    statesTopo as unknown as Topology<{ states: GeometryCollection }>,
-    (statesTopo as unknown as Topology<{ states: GeometryCollection }>).objects
-      .states,
-  ) as unknown as ExtendedFeatureCollection;
+  const world = worldTopo as unknown as WorldTopology;
+  const states = statesTopo as unknown as StatesTopology;
 
   const initialProjection = createGlobeProjection({
     width: GLOBE_WIDTH,
@@ -45,15 +39,18 @@ export default function MapPage() {
     rotation: INITIAL_ROTATION,
   });
   const initialCountryPaths = pathsFromGeojson(
-    worldFeatures,
+    feature(
+      world,
+      world.objects.countries,
+    ) as unknown as ExtendedFeatureCollection,
     initialProjection,
   );
 
   return (
     <MapGlobe
       pins={pins}
-      worldFeatures={worldFeatures}
-      stateFeatures={stateFeatures}
+      worldTopo={world}
+      statesTopo={states}
       initialRotation={INITIAL_ROTATION}
       initialScale={INITIAL_SCALE}
       initialCountryPaths={initialCountryPaths}

--- a/components/map/MapGlobe.tsx
+++ b/components/map/MapGlobe.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ExtendedFeatureCollection } from "d3-geo";
+import { feature } from "topojson-client";
+import type { GeometryCollection, Topology } from "topojson-specification";
 import type { MapPin } from "@/lib/content";
 import {
   createGlobeProjection,
@@ -18,6 +20,9 @@ import {
 import { cubicBezierEase, lerpRotation, lerpScale } from "@/lib/tween";
 import { PinPopover } from "./PinPopover";
 
+export type WorldTopology = Topology<{ countries: GeometryCollection }>;
+export type StatesTopology = Topology<{ states: GeometryCollection }>;
+
 const GLOBE_DURATION_MS = 750;
 const GLOBE_EASE = cubicBezierEase(0.2, 0, 0, 1);
 
@@ -33,8 +38,8 @@ const DRIFT_MIN_RELEASE_SPEED = 0.15;
 
 export interface MapGlobeProps {
   pins: MapPin[];
-  worldFeatures: ExtendedFeatureCollection;
-  stateFeatures: ExtendedFeatureCollection;
+  worldTopo: WorldTopology;
+  statesTopo: StatesTopology;
   initialRotation: [number, number];
   initialScale: number;
   initialCountryPaths: string[];
@@ -42,8 +47,8 @@ export interface MapGlobeProps {
 
 export function MapGlobe({
   pins,
-  worldFeatures,
-  stateFeatures,
+  worldTopo,
+  statesTopo,
   initialRotation,
   initialScale,
   initialCountryPaths,
@@ -55,6 +60,26 @@ export function MapGlobe({
     prefersReducedMotion ? "user" : "auto",
   );
   const [openPinId, setOpenPinId] = useState<string | null>(null);
+
+  // Materialize features from topology once on the client. Shipping the raw
+  // TopoJSON (arc-encoded, shared boundaries) rather than the expanded
+  // FeatureCollection roughly halves the /map RSC payload.
+  const worldFeatures = useMemo(
+    () =>
+      feature(
+        worldTopo,
+        worldTopo.objects.countries,
+      ) as unknown as ExtendedFeatureCollection,
+    [worldTopo],
+  );
+  const stateFeatures = useMemo(
+    () =>
+      feature(
+        statesTopo,
+        statesTopo.objects.states,
+      ) as unknown as ExtendedFeatureCollection,
+    [statesTopo],
+  );
 
   const { countryPaths, statePaths, projectedPins } = useMemo(() => {
     const projection = createGlobeProjection({


### PR DESCRIPTION
Closes #14.

## Summary

- `app/map/page.tsx` passes raw `worldTopo` / `statesTopo` objects to `<MapGlobe>` instead of materialized `ExtendedFeatureCollection`s. The server still calls `feature()` once to compute `initialCountryPaths` (SSR hydration parity).
- `components/map/MapGlobe.tsx` calls `feature()` client-side inside `useMemo`s keyed on topology identity. Exports `WorldTopology` / `StatesTopology` types so the page can type its props.

The FeatureCollections were ~5× larger than the source TopoJSON (arcs expanded, shared country boundaries duplicated) and were only used client-side for drag/zoom re-projection — so they never needed to cross the network.

## Measured payload impact

Built against `/map` (`next build`, production):

| | Before | After | Δ |
|---|---|---|---|
| `.next/server/app/map.html` | 1,288,738 | 494,985 | **−61.6%** |
| `map.html` gzipped | 470,803 | 171,972 | **−63.5%** |
| `.next/server/app/map.rsc` | 1,136,858 | 344,441 | **−69.7%** |
| `map.rsc` gzipped | 424,524 | 125,600 | **−70.4%** |

Well beyond the 30–40% estimate in #14 — replacing the FeatureCollections with raw topology is a bigger win than expected because shared borders collapse back to single arcs.

## Test plan

- [x] `npm test` — 81/81 pass
- [x] `npm run typecheck` — clean
- [x] `npm run build` — succeeds, payload numbers captured above
- [x] `npm run dev` → `GET /map` → `200`, SSR HTML contains 144 country `<path>` elements (hydration parity preserved), no console/server errors
- [ ] Manual QA in a browser: first paint looks correct, drag/zoom feel unchanged, `#<pin-id>` hash still flies to the pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)