### PR TITLE
feat(home): headshot + socials + Chronicle article refs

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import {
   getAboutPage,
   getBlogPosts,
@@ -43,7 +44,42 @@ export default function Home() {
   return (
     <PageContainer>
       <section id="about">
+        <Image
+          src="/headshot_white.png"
+          alt="Illustrated portrait of Senou Kounouho"
+          width={800}
+          height={801}
+          priority
+          quality={95}
+          sizes="96px"
+          className="mb-[var(--space-block)] h-24 w-24 rounded-full object-cover"
+        />
         <article className="prose-site w-full">{renderMdx(about.body)}</article>
+        <ul
+          className="mt-[var(--space-block)] flex flex-wrap gap-x-5 gap-y-2 font-sans text-sm"
+          style={{ color: "var(--fg-muted)" }}
+        >
+          <li>
+            <a
+              href="https://www.linkedin.com/in/kounouho/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="no-underline transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)] hover:text-[color:var(--accent)]"
+            >
+              LinkedIn
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://x.com/SenouKounouho"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="no-underline transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)] hover:text-[color:var(--accent)]"
+            >
+              X
+            </a>
+          </li>
+        </ul>
       </section>
 
       <hr

--- a/components/resume/WorkEntry.tsx
+++ b/components/resume/WorkEntry.tsx
@@ -69,6 +69,20 @@ export function WorkEntry({
                 )}
             </div>
           )}
+          {entry.articles.length > 0 && (
+            <div className="text-sm" style={{ color: "var(--fg-muted)" }}>
+              <div className="font-sans mb-1">Selected articles</div>
+              <ul className="space-y-1">
+                {entry.articles.map((a) => (
+                  <li key={a.url}>
+                    <a href={a.url} target="_blank" rel="noopener noreferrer">
+                      {a.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       </details>
     </article>

--- a/content/resume/work.yaml
+++ b/content/resume/work.yaml
@@ -153,3 +153,19 @@
   category: teaching-other
   blog_slugs: []
   map_pin_ids: [durham]
+  articles:
+    - title: "'Partners in the work': DSG President Isaiah Hamilton to focus on inclusivity, collaboration with student groups in presidency"
+      url: https://www.dukechronicle.com/article/2023/05/duke-university-duke-student-government-dsg-isaiah-hamilton-president
+      date: "2023-05-24"
+    - title: "'Their Duke experience is just beginning': NBA Commissioner, commencement speaker Adam Silver recalls time at Duke"
+      url: https://www.dukechronicle.com/article/2023/05/duke-university-adam-silver-commencement-class-of-2023-national-basketball-association
+      date: "2023-05-09"
+    - title: "Student Organization Finance Committee presents proposed overhaul of student group funding process to DSG Senate"
+      url: https://www.dukechronicle.com/article/2023/03/duke-student-organization-finance-committee-presents-proposed-overhaul-of-student-group-funding-process-at-dsg-senate-office-of-student-affairs
+      date: "2023-03-30"
+    - title: "'Too many people take voting for granted': Duke Democracy Day highlights youth voting as midterms near"
+      url: https://www.dukechronicle.com/article/2022/10/duke-university-democracy-day-voting-north-carolina-durham-midterm-elections-youth-voters
+      date: "2022-10-31"
+    - title: "Inaugural cohort of Duke Forest Stewards promotes sustainable recreation, provides critical help to staff"
+      url: https://www.dukechronicle.com/article/2022/10/duke-university-forest-inaugural-cohort-of-duke-forest-stewards-promote-sustainable-recreation-provide-critical-capacity-to-staff
+      date: "2022-10-04"

--- a/lib/content/__tests__/resume-sections.test.ts
+++ b/lib/content/__tests__/resume-sections.test.ts
@@ -18,6 +18,7 @@ const work = (over: Partial<WorkEntry>): WorkEntry => ({
   category: "paid",
   blog_slugs: [],
   map_pin_ids: [],
+  articles: [],
   ...over,
 });
 

--- a/lib/content/schemas.ts
+++ b/lib/content/schemas.ts
@@ -65,6 +65,13 @@ export const workEntrySchema = yearMonthRange({
   category: workCategory,
   blog_slugs: z.array(kebabCase).default([]),
   map_pin_ids: z.array(kebabCase).default([]),
+  articles: z
+    .array(
+      z
+        .object({ title: z.string().min(1), url, date: isoDate.optional() })
+        .strict(),
+    )
+    .default([]),
 });
 
 export type WorkEntry = z.infer<typeof workEntrySchema>;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    qualities: [75, 95],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Circular 96px headshot at the top of the About section (quality 95, `priority`).
- LinkedIn + X social links in a small UI-chrome row before the About/Resume divider.
- New optional `articles: [{ title, url, date? }]` field on work entries; renders a "Selected articles" block under highlights. Populated for the Chronicle with five published pieces.
- `next.config.ts`: allowlist image quality 95 (Next 16 coerces non-listed qualities to 75 by default).

## Test plan
- [x] `npm test` — 92/92 passing
- [x] `npm run typecheck` — clean
- [ ] Preview deploy renders headshot crisply (q=95 variant), socials hover to accent, Chronicle row expands to show 5 article links
- [ ] Dark mode parity on new elements