### PR TITLE
feat: add GitHub social link and default to dark mode

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -79,6 +79,16 @@ export default function Home() {
               X
             </a>
           </li>
+          <li>
+            <a
+              href="https://github.com/skounouho"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="no-underline transition-colors duration-[var(--duration-fast)] ease-[var(--ease-standard)] hover:text-[color:var(--accent)]"
+            >
+              GitHub
+            </a>
+          </li>
         </ul>
       </section>
 

--- a/components/nav/theme-script.tsx
+++ b/components/nav/theme-script.tsx
@@ -7,11 +7,10 @@ const script = `
 (function () {
   try {
     var stored = window.localStorage.getItem('theme');
-    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    var theme = stored === 'light' || stored === 'dark' ? stored : (prefersDark ? 'dark' : 'light');
+    var theme = stored === 'light' || stored === 'dark' ? stored : 'dark';
     document.documentElement.setAttribute('data-theme', theme);
   } catch (e) {
-    document.documentElement.setAttribute('data-theme', 'light');
+    document.documentElement.setAttribute('data-theme', 'dark');
   }
 })();
 `;


### PR DESCRIPTION
## Summary
- Add GitHub (https://github.com/skounouho) to the socials list on the About section, matching the existing LinkedIn/X styling.
- Default the site to dark mode when no theme preference is stored (previously fell back to `prefers-color-scheme`). Stored user toggles still win.

## Test plan
- [x] Verify About section shows LinkedIn / X / GitHub with matching hover styles
- [x] Fresh browser (no localStorage) loads in dark mode regardless of OS theme
- [x] Theme toggle still switches and persists across reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)