### PR TITLE
Add park kind and ten new map pins

### DIFF
--- a/app/theme.css
+++ b/app/theme.css
@@ -11,6 +11,7 @@
   --fg-muted: #6b6660;
   --border: #e3ded6;
   --accent: #8a6f4f;
+  --accent-park: #4f7a75;
 
   --font-serif: "Alegreya Variable", Georgia, serif;
   --font-sans: "Lato", system-ui, sans-serif;
@@ -32,6 +33,7 @@
   --fg-muted: #8f8a82;
   --border: #2e2a26;
   --accent: #b8986e;
+  --accent-park: #7ba39e;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/components/map/MapGlobe.tsx
+++ b/components/map/MapGlobe.tsx
@@ -528,67 +528,82 @@ export function MapGlobe({
           ))}
         </g>
         <g>
-          {projectedClusters.map(({ cluster, x, y }) => (
-            <g
-              key={cluster.id}
-              tabIndex={0}
-              role="button"
-              aria-label={cluster.name}
-              className="group outline-none"
-              style={{ cursor: "pointer" }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  (document.querySelector(
-                    `[data-pin="${cluster.id}"]`,
-                  ) as SVGCircleElement | null)?.dispatchEvent(
-                    new MouseEvent("click", { bubbles: true }),
-                  );
-                }
-              }}
-            >
-              <circle
-                cx={x}
-                cy={y}
-                r={8}
-                fill="none"
-                stroke="var(--fg-muted)"
-                strokeWidth={1.5}
-                vectorEffect="non-scaling-stroke"
-                className="opacity-0 group-focus-visible:opacity-100 transition-opacity duration-[var(--duration-fast)]"
-                aria-hidden="true"
-              />
-              <circle
-                data-pin={cluster.id}
-                cx={x}
-                cy={y}
-                r={4.8}
-                fill="var(--accent)"
-                stroke="var(--bg)"
-                strokeWidth={1.6}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (openClusterId === cluster.id) {
-                    setOpenClusterId(null);
-                    return;
+          {projectedClusters.map(({ cluster, x, y }) => {
+            const isPark = cluster.pins.every((p) => p.kind === "park");
+            const handlePinClick = (e: React.MouseEvent) => {
+              e.stopPropagation();
+              if (openClusterId === cluster.id) {
+                setOpenClusterId(null);
+                return;
+              }
+              if (prefersReducedMotion) {
+                cancelDrift();
+                const target = flyToTarget(cluster);
+                setRotation(target.rotation);
+                setScale(target.scale);
+                setMode("user");
+                setOpenClusterId(cluster.id);
+                return;
+              }
+              setOpenClusterId(null);
+              startFlyTo(cluster, () => setOpenClusterId(cluster.id));
+            };
+            return (
+              <g
+                key={cluster.id}
+                tabIndex={0}
+                role="button"
+                aria-label={cluster.name}
+                className="group outline-none"
+                style={{ cursor: "pointer" }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    (document.querySelector(
+                      `[data-pin="${cluster.id}"]`,
+                    ) as SVGElement | null)?.dispatchEvent(
+                      new MouseEvent("click", { bubbles: true }),
+                    );
                   }
-                  if (prefersReducedMotion) {
-                    cancelDrift();
-                    const target = flyToTarget(cluster);
-                    setRotation(target.rotation);
-                    setScale(target.scale);
-                    setMode("user");
-                    setOpenClusterId(cluster.id);
-                    return;
-                  }
-                  // Close any existing popover before flying.
-                  setOpenClusterId(null);
-                  startFlyTo(cluster, () => setOpenClusterId(cluster.id));
                 }}
-              />
-            </g>
-          ))}
+              >
+                <circle
+                  cx={x}
+                  cy={y}
+                  r={8}
+                  fill="none"
+                  stroke="var(--fg-muted)"
+                  strokeWidth={1.5}
+                  vectorEffect="non-scaling-stroke"
+                  className="opacity-0 group-focus-visible:opacity-100 transition-opacity duration-[var(--duration-fast)]"
+                  aria-hidden="true"
+                />
+                {isPark ? (
+                  <polygon
+                    data-pin={cluster.id}
+                    points={`${x},${y - 5.8} ${x - 5},${y + 2.9} ${x + 5},${y + 2.9}`}
+                    fill="var(--accent-park)"
+                    stroke="var(--bg)"
+                    strokeWidth={1.6}
+                    strokeLinejoin="round"
+                    onClick={handlePinClick}
+                  />
+                ) : (
+                  <circle
+                    data-pin={cluster.id}
+                    cx={x}
+                    cy={y}
+                    r={4.8}
+                    fill="var(--accent)"
+                    stroke="var(--bg)"
+                    strokeWidth={1.6}
+                    onClick={handlePinClick}
+                  />
+                )}
+              </g>
+            );
+          })}
         </g>
       </svg>
 

--- a/components/map/MapGlobe.tsx
+++ b/components/map/MapGlobe.tsx
@@ -61,6 +61,7 @@ export function MapGlobe({
     prefersReducedMotion ? "user" : "auto",
   );
   const [openClusterId, setOpenClusterId] = useState<string | null>(null);
+  const [hoveredClusterId, setHoveredClusterId] = useState<string | null>(null);
 
   const clusters = useMemo(() => clusterPins(pins), [pins]);
 
@@ -528,7 +529,13 @@ export function MapGlobe({
           ))}
         </g>
         <g>
-          {projectedClusters.map(({ cluster, x, y }) => {
+          {[...projectedClusters]
+            .sort((a, b) => {
+              const aHover = a.cluster.id === hoveredClusterId ? 1 : 0;
+              const bHover = b.cluster.id === hoveredClusterId ? 1 : 0;
+              return aHover - bHover;
+            })
+            .map(({ cluster, x, y }) => {
             const isPark = cluster.pins.every((p) => p.kind === "park");
             const handlePinClick = (e: React.MouseEvent) => {
               e.stopPropagation();
@@ -556,6 +563,18 @@ export function MapGlobe({
                 aria-label={cluster.name}
                 className="group outline-none"
                 style={{ cursor: "pointer" }}
+                onPointerEnter={() => setHoveredClusterId(cluster.id)}
+                onPointerLeave={() =>
+                  setHoveredClusterId((id) =>
+                    id === cluster.id ? null : id,
+                  )
+                }
+                onFocus={() => setHoveredClusterId(cluster.id)}
+                onBlur={() =>
+                  setHoveredClusterId((id) =>
+                    id === cluster.id ? null : id,
+                  )
+                }
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
@@ -571,7 +590,7 @@ export function MapGlobe({
                 <circle
                   cx={x}
                   cy={y}
-                  r={8}
+                  r={7.2}
                   fill="none"
                   stroke="var(--fg-muted)"
                   strokeWidth={1.5}
@@ -579,28 +598,16 @@ export function MapGlobe({
                   className="opacity-0 group-focus-visible:opacity-100 transition-opacity duration-[var(--duration-fast)]"
                   aria-hidden="true"
                 />
-                {isPark ? (
-                  <polygon
-                    data-pin={cluster.id}
-                    points={`${x},${y - 5.8} ${x - 5},${y + 2.9} ${x + 5},${y + 2.9}`}
-                    fill="var(--accent-park)"
-                    stroke="var(--bg)"
-                    strokeWidth={1.6}
-                    strokeLinejoin="round"
-                    onClick={handlePinClick}
-                  />
-                ) : (
-                  <circle
-                    data-pin={cluster.id}
-                    cx={x}
-                    cy={y}
-                    r={4.8}
-                    fill="var(--accent)"
-                    stroke="var(--bg)"
-                    strokeWidth={1.6}
-                    onClick={handlePinClick}
-                  />
-                )}
+                <circle
+                  data-pin={cluster.id}
+                  cx={x}
+                  cy={y}
+                  r={4.32}
+                  fill={isPark ? "var(--accent-park)" : "var(--accent)"}
+                  stroke="var(--bg)"
+                  strokeWidth={1}
+                  onClick={handlePinClick}
+                />
               </g>
             );
           })}

--- a/content/map.yaml
+++ b/content/map.yaml
@@ -146,3 +146,99 @@
     Duke vs. UConn, March Madness 2026 at Capital One Arena. A
     tough game to watch.
   blog_slugs: []
+
+- id: phoenix
+  name: Phoenix, AZ
+  kind: lived
+  lat: 33.4484
+  lon: -112.0740
+  start: "2014-08"
+  end: "2022-05"
+  description: |
+    Eight years at BASIS Peoria, from fifth through twelfth grade.
+  blog_slugs: []
+
+- id: oxford
+  name: Oxford, UK
+  kind: visited
+  lat: 51.7520
+  lon: -1.2577
+  start: "2023-07"
+  end: "2023-08"
+  description: |
+    Summer study abroad at Oxford.
+  blog_slugs: []
+
+- id: cotonou
+  name: Cotonou, Benin
+  kind: visited
+  lat: 6.3703
+  lon: 2.3912
+  start: "2022-05"
+  end: "2022-05"
+  description: |
+    A visit home — my father's hometown.
+  blog_slugs: []
+
+- id: osaka
+  name: Osaka, Japan
+  kind: visited
+  lat: 34.6937
+  lon: 135.5023
+  description: |
+    My mother's hometown.
+  blog_slugs: []
+
+- id: yosemite
+  name: Yosemite National Park
+  kind: park
+  lat: 37.8651
+  lon: -119.5383
+  description: |
+    Granite walls and waterfalls in the Sierra Nevada.
+  blog_slugs: []
+
+- id: grand-canyon
+  name: Grand Canyon National Park
+  kind: park
+  lat: 36.1069
+  lon: -112.1129
+  description: |
+    The South Rim of the Grand Canyon.
+  blog_slugs: []
+
+- id: zion
+  name: Zion National Park
+  kind: park
+  lat: 37.2982
+  lon: -113.0263
+  description: |
+    Red sandstone canyons in southern Utah.
+  blog_slugs: []
+
+- id: bryce-canyon
+  name: Bryce Canyon National Park
+  kind: park
+  lat: 37.5930
+  lon: -112.1871
+  description: |
+    Amphitheaters of hoodoos above 8,000 feet.
+  blog_slugs: []
+
+- id: joshua-tree
+  name: Joshua Tree National Park
+  kind: park
+  lat: 33.8734
+  lon: -115.9010
+  description: |
+    High desert where the Mojave meets the Colorado.
+  blog_slugs: []
+
+- id: smoky-mountains
+  name: Great Smoky Mountains National Park
+  kind: park
+  lat: 35.6118
+  lon: -83.4895
+  description: |
+    Ridge-and-valley forests along the Tennessee–North Carolina line.
+  blog_slugs: []

--- a/lib/__tests__/format.test.ts
+++ b/lib/__tests__/format.test.ts
@@ -27,4 +27,8 @@ describe("formatYearMonthRange", () => {
   it("renders an open-ended range with 'Present' when end is null", () => {
     expect(formatYearMonthRange("2024-01", null)).toBe("Jan 2024 – Present");
   });
+
+  it("collapses a same-month range to a single label", () => {
+    expect(formatYearMonthRange("2022-05", "2022-05")).toBe("May 2022");
+  });
 });

--- a/lib/content/schemas.ts
+++ b/lib/content/schemas.ts
@@ -143,6 +143,7 @@ export const mapPinKind = z.enum([
   "visited",
   "conference",
   "research",
+  "park",
 ]);
 
 export const mapPinSchema = yearMonthRange({

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -23,6 +23,7 @@ export function formatYearMonthRange(
   end: string | null,
 ): string {
   const left = formatYearMonth(start);
+  if (end !== null && end === start) return left;
   const right = end === null ? "Present" : formatYearMonth(end);
   return `${left} – ${right}`;
 }


### PR DESCRIPTION
## Summary
- Adds a new `park` map kind rendered as a small muted-teal triangle (new `--accent-park` token in `app/theme.css`). All-park clusters use the triangle; mixed or non-park clusters keep the existing circle.
- Adds four personal cities: Phoenix, AZ (BASIS Peoria, 2014–2022, `lived`), Oxford, UK (study abroad 2023, `visited`), Cotonou, Benin (May 2022, `visited`), Osaka, Japan (no dates, `visited`).
- Adds six national parks as `park` pins: Yosemite, Grand Canyon, Zion, Bryce Canyon, Joshua Tree, Great Smoky Mountains.

## Notes
- Phoenix uses Phoenix city-center coords rather than BASIS Peoria's actual location — happy to nudge if preferred.
- Osaka has no start/end since it was described as a heritage pin.

## Test plan
- [x] `npm test` — 102/102 passing
- [x] `npm run build` — clean production build
- [ ] Visual check on the globe: park pins render as teal triangles, existing pins unchanged