### PR TITLE
Add password gate for the blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ npm run typecheck  # tsc --noEmit
 
 - `NEXT_PUBLIC_SITE_URL` — canonical site URL (used for OG / sitemap / robots).
   Required at build time when not deployed on Vercel.
-- `SITE_PASSWORD` — optional shared password that gates the entire site.
-  When set, all routes redirect to `/unlock` until the visitor enters the
-  password; a long-lived `site_unlock` cookie keeps them in until the browser
-  clears it. Leave unset locally to skip the gate.
+- `SITE_PASSWORD` — optional shared password that gates the `/blog` tree
+  (index and every post, including OG images). The rest of the site stays
+  public. When set, blog requests redirect to `/unlock` until the visitor
+  enters the password; a long-lived `site_unlock` cookie keeps them in until
+  the browser clears it. Leave unset locally to skip the gate.
 
 ## Repo layout
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ npm run lint       # eslint
 npm run typecheck  # tsc --noEmit
 ```
 
+## Environment variables
+
+- `NEXT_PUBLIC_SITE_URL` — canonical site URL (used for OG / sitemap / robots).
+  Required at build time when not deployed on Vercel.
+- `SITE_PASSWORD` — optional shared password that gates the entire site.
+  When set, all routes redirect to `/unlock` until the visitor enters the
+  password; a long-lived `site_unlock` cookie keeps them in until the browser
+  clears it. Leave unset locally to skip the gate.
+
 ## Repo layout
 
 - `app/` — App Router pages (home, blog, map)

--- a/app/unlock/page.tsx
+++ b/app/unlock/page.tsx
@@ -1,0 +1,116 @@
+import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import {
+  UNLOCK_COOKIE_NAME,
+  signUnlockToken,
+  verifyUnlockToken,
+} from "@/lib/auth/site-gate";
+
+export const metadata: Metadata = {
+  title: "Unlock",
+  robots: { index: false, follow: false },
+};
+
+const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
+
+function safeNextPath(raw: unknown): string {
+  if (typeof raw !== "string") return "/";
+  // Only allow same-origin absolute paths. Reject protocol-relative and
+  // anything that isn't a single-leading-slash path.
+  if (!raw.startsWith("/") || raw.startsWith("//")) return "/";
+  return raw;
+}
+
+async function unlockAction(formData: FormData) {
+  "use server";
+  const password = process.env.SITE_PASSWORD;
+  const submitted = formData.get("password");
+  const next = safeNextPath(formData.get("next"));
+
+  if (!password || typeof submitted !== "string" || submitted !== password) {
+    const params = new URLSearchParams({ error: "1" });
+    if (next !== "/") params.set("next", next);
+    redirect(`/unlock?${params.toString()}`);
+  }
+
+  const cookieStore = await cookies();
+  cookieStore.set({
+    name: UNLOCK_COOKIE_NAME,
+    value: signUnlockToken(password),
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: ONE_YEAR_SECONDS,
+  });
+
+  redirect(next);
+}
+
+interface SearchParams {
+  next?: string;
+  error?: string;
+}
+
+export default async function UnlockPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const { next: rawNext, error } = await searchParams;
+  const next = safeNextPath(rawNext);
+
+  // If the user is already unlocked, send them along.
+  const password = process.env.SITE_PASSWORD;
+  if (password) {
+    const cookieStore = await cookies();
+    const token = cookieStore.get(UNLOCK_COOKIE_NAME)?.value;
+    if (verifyUnlockToken(token, password)) redirect(next);
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-6">
+      <form
+        action={unlockAction}
+        className="font-sans w-full max-w-xs flex flex-col gap-6"
+        noValidate
+      >
+        <label htmlFor="password" className="text-sm text-[var(--fg-muted)]">
+          Password
+        </label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          autoFocus
+          autoComplete="current-password"
+          aria-invalid={error ? "true" : undefined}
+          aria-describedby={error ? "unlock-error" : undefined}
+          className="
+            font-sans text-base bg-transparent
+            border-0 border-b border-[var(--border)]
+            py-2 px-0 focus:border-[var(--accent)]
+            transition-colors duration-[120ms]
+          "
+        />
+        <input type="hidden" name="next" value={next} />
+        {error ? (
+          <p id="unlock-error" className="text-sm text-[var(--fg-muted)]">
+            Incorrect password.
+          </p>
+        ) : null}
+        <button
+          type="submit"
+          className="
+            self-start text-sm tracking-wide
+            text-[var(--fg-muted)] hover:text-[var(--accent)]
+            transition-colors duration-[120ms]
+          "
+        >
+          Enter →
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/unlock/page.tsx
+++ b/app/unlock/page.tsx
@@ -91,6 +91,7 @@ export default async function UnlockPage({
             font-sans text-base bg-transparent
             border-0 border-b border-[var(--border)]
             py-2 px-0 focus:border-[var(--accent)]
+            focus-visible:outline-none
             transition-colors duration-[120ms]
           "
         />

--- a/components/nav/FloatingNav.tsx
+++ b/components/nav/FloatingNav.tsx
@@ -26,6 +26,7 @@ function isActive(pathname: string, href: string): boolean {
 
 export function FloatingNav() {
   const pathname = usePathname();
+  if (pathname === "/unlock") return null;
   return (
     <>
       {/* Desktop: left edge, vertical */}

--- a/lib/auth/__tests__/site-gate.test.ts
+++ b/lib/auth/__tests__/site-gate.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  signUnlockToken,
+  verifyUnlockToken,
+  UNLOCK_COOKIE_NAME,
+} from "@/lib/auth/site-gate";
+
+describe("signUnlockToken", () => {
+  it("produces a stable, deterministic token for a given password", () => {
+    const a = signUnlockToken("hunter2");
+    const b = signUnlockToken("hunter2");
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("produces different tokens for different passwords", () => {
+    expect(signUnlockToken("a")).not.toBe(signUnlockToken("b"));
+  });
+});
+
+describe("verifyUnlockToken", () => {
+  it("accepts a token signed with the same password", () => {
+    const token = signUnlockToken("hunter2");
+    expect(verifyUnlockToken(token, "hunter2")).toBe(true);
+  });
+
+  it("rejects a token signed with a different password", () => {
+    const token = signUnlockToken("hunter2");
+    expect(verifyUnlockToken(token, "letmein")).toBe(false);
+  });
+
+  it("rejects undefined or empty tokens", () => {
+    expect(verifyUnlockToken(undefined, "hunter2")).toBe(false);
+    expect(verifyUnlockToken("", "hunter2")).toBe(false);
+  });
+
+  it("rejects malformed tokens without crashing", () => {
+    expect(verifyUnlockToken("not-a-real-token", "hunter2")).toBe(false);
+    expect(verifyUnlockToken("a".repeat(63), "hunter2")).toBe(false);
+    expect(verifyUnlockToken("z".repeat(64), "hunter2")).toBe(false);
+  });
+
+  it("rejects when the configured password is empty", () => {
+    const token = signUnlockToken("hunter2");
+    expect(verifyUnlockToken(token, "")).toBe(false);
+  });
+});
+
+describe("UNLOCK_COOKIE_NAME", () => {
+  it("is a stable, non-empty string", () => {
+    expect(typeof UNLOCK_COOKIE_NAME).toBe("string");
+    expect(UNLOCK_COOKIE_NAME.length).toBeGreaterThan(0);
+  });
+});

--- a/lib/auth/site-gate.ts
+++ b/lib/auth/site-gate.ts
@@ -1,0 +1,27 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+export const UNLOCK_COOKIE_NAME = "site_unlock";
+
+const TOKEN_PREFIX = "v1:";
+
+function hash(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+export function signUnlockToken(password: string): string {
+  return hash(TOKEN_PREFIX + password);
+}
+
+export function verifyUnlockToken(
+  token: string | undefined,
+  password: string,
+): boolean {
+  if (!token || !password) return false;
+  const expected = signUnlockToken(password);
+  if (token.length !== expected.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(token), Buffer.from(expected));
+  } catch {
+    return false;
+  }
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -18,8 +18,7 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    // Gate everything except the unlock route and the assets it needs to render.
-    "/((?!unlock|_next/static|_next/image|favicon\\.ico|icon\\.svg).*)",
-  ],
+  // Gate the blog index and every post (including OG images, so post titles
+  // don't leak via social previews). The rest of the site stays public.
+  matcher: ["/blog", "/blog/:path*"],
 };

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,25 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { UNLOCK_COOKIE_NAME, verifyUnlockToken } from "@/lib/auth/site-gate";
+
+export function proxy(request: NextRequest) {
+  const password = process.env.SITE_PASSWORD;
+
+  // Gate disabled when SITE_PASSWORD is unset (local dev convenience).
+  if (!password) return NextResponse.next();
+
+  const token = request.cookies.get(UNLOCK_COOKIE_NAME)?.value;
+  if (verifyUnlockToken(token, password)) return NextResponse.next();
+
+  const url = request.nextUrl;
+  const next = url.pathname + url.search;
+  const unlock = new URL("/unlock", request.url);
+  if (next && next !== "/") unlock.searchParams.set("next", next);
+  return NextResponse.redirect(unlock);
+}
+
+export const config = {
+  matcher: [
+    // Gate everything except the unlock route and the assets it needs to render.
+    "/((?!unlock|_next/static|_next/image|favicon\\.ico|icon\\.svg).*)",
+  ],
+};


### PR DESCRIPTION
## Summary
- Adds an optional shared-password gate scoped to the **`/blog` tree only** (index, individual posts, and post OG images). The rest of the site (`/`, `/map`, etc.) stays public.
- Configured via the `SITE_PASSWORD` env var on Vercel. Leave it unset to disable the gate (dev convenience).
- Implemented as a Next.js 16 Proxy (renamed from Middleware in v16) plus a small `/unlock` page that uses a Server Action.
- A long-lived `httpOnly`/`SameSite=Lax`/`Secure`-in-prod cookie keeps the visitor unlocked until they clear it.

## Why a fresh PR
PR #26 was merged into the `restructure-root-docs` branch (its base) instead of `main`, so the password gate never landed on `main`. This PR cherry-picks the password-gate work onto the current `main` and adds the requested scope change (`/blog` only).

## How it works
- `proxy.ts` matcher: `["/blog", "/blog/:path*"]`. If `SITE_PASSWORD` is unset, all traffic passes through. Otherwise it requires a valid `site_unlock` cookie or 307s to `/unlock?next=<path>`.
- The cookie value is a SHA-256 hash of `"v1:" + SITE_PASSWORD` compared in constant time. Leaked cookies don't reveal the password, and rotating `SITE_PASSWORD` invalidates every active session.
- `app/unlock/page.tsx` is a server-rendered form (no JS required) that uses an inline Server Action to validate and set the cookie.
- `next=` redirect target is restricted to same-origin paths (rejects `//evil.com`).
- Floating side nav is hidden on `/unlock` so the gate stays minimal.

## Configuration
Set `SITE_PASSWORD` on Vercel under Project Settings → Environment Variables (Production + Preview as needed) and redeploy. Documented in `README.md`.

## Test plan
- [x] `npm test` — 111 passing (8 new for the gate logic).
- [x] `npm run lint` clean.
- [x] `npm run typecheck` clean.
- [x] Verified scope end-to-end via curl with `SITE_PASSWORD=hunter2`:
  - `GET /` → 200 (public)
  - `GET /map` → 200 (public)
  - `GET /blog` → 307 to `/unlock?next=/blog` (gated)
  - `GET /blog/when-in-rome` → 307 to `/unlock?next=/blog/when-in-rome` (gated)
  - With valid cookie, `GET /blog` → 200
- [x] Verified open-redirect protection (`next=//evil.com` falls back to `/`).
- [x] Verified gate disabled when `SITE_PASSWORD` unset.
- [ ] Manually verify the `/unlock` form renders correctly in light and dark mode in a browser.
- [ ] Set `SITE_PASSWORD` on a Vercel preview deploy and confirm the gate works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)