### PR TITLE
Add 2001: A Space Odyssey post and media reflection template

### DIFF
--- a/content/blog/2026-05-14-2001-a-space-odyssey.mdx
+++ b/content/blog/2026-05-14-2001-a-space-odyssey.mdx
@@ -1,0 +1,28 @@
+---
+title: "2001: A Space Odyssey"
+date: 2026-05-14
+description: "Notes on HAL, the star child, and our reliance on intelligent machines."
+tags: [film]
+draft: false
+places: []
+---
+
+## Summary
+
+After an ancient black metal prism is unearthed on the Moon, a space mission to Jupiter seeks to explain the prism's origin and the possibility of intelligent life.
+
+## Moment
+
+The moment when HAL attacks the spacewalking Frank stuck with me most. The scene mirrors an earlier scene when Dave spacewalks to retrieve the supposedly malfunctioning equipment. After Frank exits the space pod, the pod menacingly turns, and we see HAL's eye on the front of the pod. The eye of HAL draws parallels to the eye of Sauron for me: a red, unblinking, impersonal, and calculating iris with no emotion or remorse. The pod lunges forward, severing Frank's air support as he spirals into space.
+
+There is a biblical undertone to this scene: HAL is Cain, and Frank is Abel. In the garden of stars, previously free of evil, we witness the first murder. But while the artificial intelligence is the apparent villain, the film humanizes HAL and prompts us to ask: what would we have done? If fed the delusion of being infallible and given the choice between death and murder, wouldn't anyone take HAL's course of action? It may be HAL's self-knowledge of his existence that prevented him from acting simply as a tool.
+
+Ultimately, Dave is triumphant over the seemingly impregnable HAL. Perhaps one day, we will need to slay an electronic god of our making.
+
+## Lesson
+
+Humans use technology to feed an insatiable urge to conquer the infinite.
+
+## Question
+
+The ending sequence, where Dave witnesses what seems to be a wormhole and sees himself age in a four-dimensional space, is still puzzling. Does Dave ultimately transcend to become the star child seen at the end of the film? If so, why? Was this the intent of the intelligent beings that left the black prism on the Moon?

--- a/docs/templates/blog-media.md
+++ b/docs/templates/blog-media.md
@@ -1,0 +1,26 @@
+---
+title: ""
+date: YYYY-MM-DD
+description: ""
+tags: []
+draft: true
+places: []
+---
+
+{/*
+Media reflection prompts — for films, books, albums. Write prose under each
+heading below. Delete this block before publishing.
+
+1. Summary — one sentence.
+2. Moment — describe a particular moment and why it stuck with you.
+3. Lesson — one takeaway.
+4. Question — one question you still have.
+*/}
+
+## Summary
+
+## Moment
+
+## Lesson
+
+## Question


### PR DESCRIPTION
## Summary

- Adds `docs/templates/blog-media.md`, a four-section template (Summary / Moment / Lesson / Question) for short reflections on films, books, and albums. Lives outside `content/blog/` because the blog loader rejects any filename that doesn't match `YYYY-MM-DD-<slug>.mdx`.
- Publishes the first post written from the template: a reflection on Kubrick's *2001: A Space Odyssey* anchored on the moment HAL kills Frank.

## Test plan

- [x] `npm run dev` renders the new post at `/blog/2001-a-space-odyssey` with the four section headings.
- [x] Sitemap and blog index list the new post (it is no longer `draft`).
- [x] Template file does not appear in the blog listing or break content loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)