### PR TITLE
Add The Backrooms blog post

### DIFF
--- a/content/blog/2026-06-03-the-backrooms.mdx
+++ b/content/blog/2026-06-03-the-backrooms.mdx
@@ -1,5 +1,5 @@
 ---
-title: "*The Backrooms*"
+title: "*The Backrooms* (2026)"
 date: 2026-06-03
 description: "Notes on escapism, responsibility, and the monster we make of ourselves."
 tags: [film]

--- a/content/blog/2026-06-03-the-backrooms.mdx
+++ b/content/blog/2026-06-03-the-backrooms.mdx
@@ -1,0 +1,34 @@
+---
+title: "*The Backrooms*"
+date: 2026-06-03
+description: "Notes on escapism, responsibility, and the monster we make of ourselves."
+tags: [film]
+draft: false
+places: []
+---
+
+## Summary
+
+A struggling furniture salesman's confrontation with himself drags him, his employees, and his therapist into a maze of fear.
+
+## Moment
+
+After the therapist Mary ventures into the Backrooms and finds the salesman Clark, he forces her to help him reenact the night his relationship with his wife broke down. The scene repeats an earlier therapy session between the two, but here Clark wants to manufacture catharsis through roleplay with Mary, who acts as his wife.
+
+Mary ultimately does not oblige. Instead of coddling Clark, she explains directly to him that his whining and evasion of responsibility are his fault. She fully accepts that she cannot save Clark, just like she could not save her mother from suffering psychological decline.
+
+The extraordinary moment is when Clark accepts this truth. Though he says he would rather stay where he is, he recognizes that this is a choice he is making. He is in control, and he bears responsibility for accepting his own faults with no intention to change.
+
+But this resolution is short-lived. It is revealed that the monster roaming the Backrooms is a copy of Clark himself, complete with a peg leg and pirate tricorn. The monster is a representation of an inner monster: Clark shares his new revelation (that he does not need to change) and tries to bargain for Mary's life. But the monster kills him.
+
+While Clark finally claimed responsibility for his situation, the monster did not. The monster is stuck as a copy of his literally self-consuming past self. Who better to blame (and destroy) than himself and the therapist that failed to fix him.
+
+## Lesson
+
+When faced with pain or fear, we only ever have two choices: persist or run. But the choice is always ours. No amount of trauma removes that choice.
+
+## Question
+
+Escapism, rationalization, blame, pride – these are all ways to run from pain and fear. Clark becomes so intoxicated and comfortable in his fantasy that, despite how disturbing and foreign it is, he would rather stay than face reality.
+
+How are you building a fantasy of your own? What is your escapism protecting you from? What is the pain? And what is on the other side of that pain?


### PR DESCRIPTION
## Summary
- Adds a new film post on Kane Parsons' *The Backrooms* covering the therapy roleplay scene, the monster reveal, and the lesson on persisting vs. running from pain.

## Test plan
- [ ] Verify the post renders correctly at `/blog/2026-06-03-the-backrooms`
- [ ] Confirm it appears in the blog index in date order

🤖 Generated with [Claude Code](https://claude.com/claude-code)